### PR TITLE
doc: Minor cleanup

### DIFF
--- a/ast.go
+++ b/ast.go
@@ -8,11 +8,11 @@ var Kind = ast.NewNodeKind("PikchrBlock")
 // Block is a pikchr block.
 //
 //	```pikchr
-//	graph TD;
-//	    A-->B;
-//	    A-->C;
-//	    B-->D;
-//	    C-->D;
+//	arrow right 200% "Markdown" "Source"
+//	box rad 10px "Markdown" "Formatter" "(markdown.c)" fit
+//	arrow right 200% "HTML+SVG" "Output"
+//	arrow <-> down 70% from last box.s
+//	box same "Pikchr" "Formatter" "(pikchr.c)" fi	t
 //	```
 //
 // Its raw contents are the plain text of the pikchr diagram.

--- a/extend.go
+++ b/extend.go
@@ -18,12 +18,7 @@ import (
 //	    &pikchr.Exender{},
 //	  ),
 //	)
-type Extender struct {
-	// URL of pikchr Javascript to be included in the page.
-	//
-	// Defaults to the latest version available on cdn.jsdelivr.net.
-	// pikchrJS string
-}
+type Extender struct{}
 
 // Extend extends the provided Goldmark parser with support for pikchr
 // diagrams.

--- a/render.go
+++ b/render.go
@@ -31,7 +31,7 @@ func (r *Renderer) Render(w util.BufWriter, src []byte, node ast.Node, entering 
 			pikchr.HTMLError(),
 		)
 
-		_, _ = w.WriteString(fmt.Sprintf(`<div class="pikchr-svg" style="max-width:%dpx">`, res.Width))
+		_, _ = fmt.Fprintf(w, `<div class="pikchr-svg" style="max-width:%dpx">`, res.Width)
 		_, _ = w.Write([]byte(res.Data))
 		_, _ = w.WriteString("</div>")
 	}

--- a/transform.go
+++ b/transform.go
@@ -9,12 +9,8 @@ import (
 )
 
 // Transformer transforms a Goldmark Markdown AST with support for pikchr
-// diagrams. It makes the following transformations:
-//
-//   - replace pikchr code blocks with pikchr.Block nodes
-//   - add a pikchr.ScriptBlock node if the document uses pikchr
-type Transformer struct {
-}
+// diagrams by replacing pikchr code blocks with [Block] nodes.
+type Transformer struct{}
 
 var _pikchr = []byte("pikchr")
 


### PR DESCRIPTION
Drops references to `<script>` or ScriptBlock
since that's not needed for pikchr.

In render.go, instead of using Sprintf to generate a string,
and then writing the string to the writer,
use Fprintf to format and write directly to the writer.

Depends on #2 and #3
Those commits will show in the list for this PR until they're merged.
