### PR TITLE
test: Re-enable TestTransformer

### DIFF
--- a/render.go
+++ b/render.go
@@ -25,7 +25,7 @@ func (r *Renderer) Render(w util.BufWriter, src []byte, node ast.Node, entering 
 	n := node.(*Block)
 
 	if !entering {
-		raw := r.getLines(src, n)
+		raw := getLines(src, n)
 		res, _ := pikchr.Render(
 			string(raw),
 			pikchr.HTMLError(),
@@ -39,11 +39,11 @@ func (r *Renderer) Render(w util.BufWriter, src []byte, node ast.Node, entering 
 	return ast.WalkContinue, nil
 }
 
-func (r *Renderer) getLines(source []byte, n ast.Node) []byte {
+func getLines(source []byte, n ast.Node) []byte {
 	buf := bytes.NewBuffer([]byte{})
-	l := n.Lines().Len()
-	for i := 0; i < l; i++ {
-		line := n.Lines().At(i)
+	lines := n.Lines()
+	for i := 0; i < lines.Len(); i++ {
+		line := lines.At(i)
 		buf.Write(line.Value(source))
 	}
 	return buf.Bytes()

--- a/transform_test.go
+++ b/transform_test.go
@@ -3,106 +3,89 @@ package pikchr
 import (
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/yuin/goldmark"
 	"github.com/yuin/goldmark/ast"
 	"github.com/yuin/goldmark/parser"
 	"github.com/yuin/goldmark/text"
+	"github.com/yuin/goldmark/util"
 )
 
-// func TestTransformer(t *testing.T) {
-// 	t.Parallel()
+func TestTransformer(t *testing.T) {
+	t.Parallel()
 
-// 	tests := []struct {
-// 		desc       string
-// 		give       string
-// 		wantBodies []string
-// 		wantScript bool
-// 	}{
-// 		{
-// 			desc: "empty",
-// 			give: "",
-// 		},
-// 		{
-// 			desc: "pikchr",
-// 			give: unlines(
-// 				"```pikchr",
-// 				"foo",
-// 				"```",
-// 			),
-// 			wantBodies: []string{"foo\n"},
-// 			wantScript: true,
-// 		},
-// 		{
-// 			desc: "pikchr and not",
-// 			give: unlines(
-// 				"Foo",
-// 				"",
-// 				"```pikchr",
-// 				"foo",
-// 				"```",
-// 				"",
-// 				"Bar",
-// 				"",
-// 				"```go",
-// 				"bar",
-// 				"",
-// 				"Baz",
-// 				"",
-// 			),
-// 			wantBodies: []string{"foo\n"},
-// 			wantScript: true,
-// 		},
-// 	}
+	tests := []struct {
+		desc       string
+		give       string
+		wantBodies []string
+	}{
+		{
+			desc: "empty",
+			give: "",
+		},
+		{
+			desc: "pikchr",
+			give: unlines(
+				"```pikchr",
+				"foo",
+				"```",
+			),
+			wantBodies: []string{"foo\n"},
+		},
+		{
+			desc: "pikchr and not",
+			give: unlines(
+				"Foo",
+				"",
+				"```pikchr",
+				"foo",
+				"```",
+				"",
+				"Bar",
+				"",
+				"```go",
+				"bar",
+				"",
+				"Baz",
+				"",
+			),
+			wantBodies: []string{"foo\n"},
+		},
+	}
 
-// 	for _, tt := range tests {
-// 		tt := tt
-// 		t.Run(tt.desc, func(t *testing.T) {
-// 			t.Parallel()
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.desc, func(t *testing.T) {
+			t.Parallel()
 
-// 			p := goldmark.New().Parser()
-// 			p.AddOptions(
-// 				parser.WithASTTransformers(
-// 					util.Prioritized(&Transformer{}, 100),
-// 				),
-// 			)
+			p := goldmark.New().Parser()
+			p.AddOptions(
+				parser.WithASTTransformers(
+					util.Prioritized(&Transformer{}, 100),
+				),
+			)
 
-// 			src := []byte(tt.give)
-// 			got := p.Parse(text.NewReader(src))
+			src := []byte(tt.give)
+			got := p.Parse(text.NewReader(src))
 
-// 			var (
-// 				gotBodies []string
-// 				gotScript int
-// 			)
-// 			_ = ast.Walk(got, func(node ast.Node, enter bool) (ast.WalkStatus, error) {
-// 				if !enter {
-// 					return ast.WalkContinue, nil
-// 				}
+			var gotBodies []string
+			_ = ast.Walk(got, func(node ast.Node, enter bool) (ast.WalkStatus, error) {
+				if !enter {
+					return ast.WalkContinue, nil
+				}
 
-// 				switch n := node.(type) {
-// 				case *Block:
-// 					var buff bytes.Buffer
-// 					lines := n.Lines()
-// 					for i := 0; i < lines.Len(); i++ {
-// 						line := lines.At(i)
-// 						buff.Write(line.Value(src))
-// 					}
+				switch n := node.(type) {
+				case *Block:
+					gotBodies = append(gotBodies, string(getLines(src, n)))
+				}
 
-// 					gotBodies = append(gotBodies, buff.String())
+				return ast.WalkContinue, nil
+			})
 
-// 				}
-
-// 				return ast.WalkContinue, nil
-// 			})
-
-// 			assert.Equal(t, tt.wantBodies, gotBodies)
-// 			if tt.wantScript {
-// 				assert.Equal(t, 1, gotScript)
-// 			} else {
-// 				assert.Zero(t, gotScript)
-// 			}
-// 		})
-// 	}
-// }
+			assert.Equal(t, tt.wantBodies, gotBodies)
+		})
+	}
+}
 
 func TestTransformer_RepeatedTransformations(t *testing.T) {
 	t.Parallel()


### PR DESCRIPTION
Re-enable TestTransformer, and reuse the getLines function in render.go
to extract the contents of a pikchr.Block.

This PR is independent of the other open PRs.
