### PR TITLE
Support DarkMode option

### DIFF
--- a/extend.go
+++ b/extend.go
@@ -18,7 +18,9 @@ import (
 //	    &pikchr.Exender{},
 //	  ),
 //	)
-type Extender struct{}
+type Extender struct {
+	DarkMode bool
+}
 
 // Extend extends the provided Goldmark parser with support for pikchr
 // diagrams.
@@ -30,7 +32,7 @@ func (e *Extender) Extend(md goldmark.Markdown) {
 	)
 	md.Renderer().AddOptions(
 		renderer.WithNodeRenderers(
-			util.Prioritized(&Renderer{}, 100),
+			util.Prioritized(&Renderer{DarkMode: e.DarkMode}, 100),
 		),
 	)
 }

--- a/render.go
+++ b/render.go
@@ -12,7 +12,9 @@ import (
 
 // Renderer renders pikchr diagrams as HTML, to be rendered into images
 // client side.
-type Renderer struct{}
+type Renderer struct {
+	DarkMode bool
+}
 
 // RegisterFuncs registers the renderer for pikchr blocks with the provided
 // Goldmark Registerer.
@@ -26,9 +28,14 @@ func (r *Renderer) Render(w util.BufWriter, src []byte, node ast.Node, entering 
 
 	if !entering {
 		raw := getLines(src, n)
+		opt := []pikchr.Option{}
+		opt = append(opt, pikchr.HTMLError())
+		if r.DarkMode {
+			opt = append(opt, pikchr.Dark())
+		}
 		res, _ := pikchr.Render(
 			string(raw),
-			pikchr.HTMLError(),
+			opt...,
 		)
 
 		_, _ = fmt.Fprintf(w, `<div class="pikchr-svg" style="max-width:%dpx">`, res.Width)


### PR DESCRIPTION
The outputs of pikchr are not visible on a dark-background, this change can enable the reversed color scheme in pikchr.

```go
goldmark.WithExtensions(
   &pikchr.Extender{DarkMode:true},
)
```